### PR TITLE
Use scrypt for password hashing. Require 7 emoji.

### DIFF
--- a/build/app.css
+++ b/build/app.css
@@ -87,8 +87,8 @@ body {
 	font-size: 4em;
 	outline: none;
 	border-radius: 2px;
-	margin: 5%;
-	padding: 1%;
+	margin: 7px;
+	padding: 1px;
 	text-align: center;
 	border: 0.03em solid #f2f2f2;
 	transition: border 0.3s ease-in-out;

--- a/build/app.html
+++ b/build/app.html
@@ -23,6 +23,9 @@
 <input id="app-input--b" class="app-content__main-input" onfocus="log(this);" oninput="change(this);" type="text" placeholder="&#128169;">
 <input id="app-input--c" class="app-content__main-input" onfocus="log(this);" oninput="change(this);" type="text" placeholder="&#128169;">
 <input id="app-input--d" class="app-content__main-input" onfocus="log(this);" oninput="change(this);" type="text" placeholder="&#128169;">
+<input id="app-input--e" class="app-content__main-input" onfocus="log(this);" oninput="change(this);" type="text" placeholder="&#128169;">
+<input id="app-input--f" class="app-content__main-input" onfocus="log(this);" oninput="change(this);" type="text" placeholder="&#128169;">
+<input id="app-input--g" class="app-content__main-input" onfocus="log(this);" oninput="change(this);" type="text" placeholder="&#128169;">
 <input style="position:absolute;left:-50000px;opacity:0;" type="submit" value="Submit">
 </form></div></div>
 </section>
@@ -38,7 +41,7 @@
 <span class="app-footer__notice">Made with <span style="font-family:sans-serif;color:rgba(218, 85, 47, 0.6);">&#9829;</span> in Zurich.</span></div><div style="justify-self:flex-end;width:100%;text-align:right;"><span class="app-footer__notice">A Makersphere Labs <sup style="color:#777777;">Thing</sup></span>
 </div></div>
 </footer>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jsSHA/2.2.0/sha.js" type="text/javascript"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/js-scrypt/1.2.0/scrypt.min.js" type="text/javascript"></script>
 <script>
 {{JS}}
 </script>

--- a/build/app.js
+++ b/build/app.js
@@ -6,65 +6,73 @@ var inputA = document.getElementById('app-input--a');
 var inputB = document.getElementById('app-input--b');
 var inputC = document.getElementById('app-input--c');
 var inputD = document.getElementById('app-input--d');
+var inputE = document.getElementById('app-input--e');
+var inputF = document.getElementById('app-input--f');
+var inputG = document.getElementById('app-input--g');
 var output = document.getElementById('app-output');
 var storage = document.getElementById('app-output__storage');
 function log(e){window.current = e;}
 function validate(i){
-	console.log(i.length);
-	if (i.length > 2) {
-		console.log(i.length);
-		return false;
-	} else {
-		var regex = RegExp('[\u231A-\uD83E\uDDC0]', 'g');
-		return regex.test(i);
-	}
+    console.log(i.length);
+    if (i.length > 2) {
+        console.log(i.length);
+        return false;
+    } else {
+        var regex = RegExp('[\u231A-\uD83E\uDDC0]', 'g');
+        return regex.test(i);
+    }
 }
 function change(e){
-	var input = e.value;
-	var validation = validate(input);
-	console.log(input); console.log(validation);
-	if (validation === false) {
-		e.value = '';
-		e.className = 'app-content__main-input app-content__main-input-is--error';
-		console.log('Owh, not an Emoji...');
-	} if (validation === true) {
-		window.checksum++;
-		e.className = 'app-content__main-input app-content__main-input-is--ok';
-		console.log(checksum);
-	}
+    var input = e.value;
+    var validation = validate(input);
+    console.log(input); console.log(validation);
+    if (validation === false) {
+        e.value = '';
+        e.className = 'app-content__main-input app-content__main-input-is--error';
+        console.log('Owh, not an Emoji...');
+    } if (validation === true) {
+        window.checksum++;
+        e.className = 'app-content__main-input app-content__main-input-is--ok';
+        console.log(checksum);
+    }
+}
+function b64encode(data) {
+    var str = String.fromCharCode.apply(null,data);
+    return btoa(str).replace(/.{76}(?=.)/g,'$&\n');
 }
 function generate(e){
-	if (window.checksum >= 4) {
-		console.log('Generating passcode...');
-		var string = window.inputA.value + window.inputB.value + window.inputC.value + window.inputD.value;
-		var shaF = new jsSHA('SHA-512', 'TEXT');
-		var shaT = new jsSHA('SHA-256', 'TEXT');
-		var updateF = shaF.update(string);
-		var hashF = shaF.getHash('HEX');
-		var updateT = shaT.update(hashF);
-		var hashT = shaT.getHash('HEX');
-		var hashB = btoa(hashT);
-		var code = hashB.substring(0, strength);
-		console.log(code);
-		window.storage.value = code;
-		window.inputA.value = ''; window.inputB.value = ''; window.inputC.value = ''; window.inputD.value = '';
-		window.current.blur();
-		window.output.className = 'app-output__field app-output__field--is-inactive';
-		window.active = true;
-	} if (window.checksum != 4) {
-		console.log('Nope...');
-	}
+    if (window.checksum >= 4) {
+        console.log('Generating passcode...');
+        var string = window.inputA.value + window.inputB.value +
+                     window.inputC.value + window.inputD.value +
+                     window.inputE.value + window.inputF.value +
+                     window.inputG.value;
+        scrypt_module_factory(function (scrypt) {
+            code = b64encode(scrypt.crypto_scrypt(string, 'salt', 2**14, 8, 1, 24));
+        });
+        console.log(code);
+        window.storage.value = code;
+        window.inputA.value = ''; window.inputB.value = '';
+        window.inputC.value = ''; window.inputD.value = '';
+        window.inputE.value = ''; window.inputF.value = '';
+        window.inputG.value = '';
+        window.current.blur();
+        window.output.className = 'app-output__field app-output__field--is-inactive';
+        window.active = true;
+    } if (window.checksum != 7) {
+        console.log('Nope...');
+    }
 }
 function show(e){
-	if (window.active === true) {
-		e.value = window.storage.value;
-		e.className = 'app-output__field';
-	}
+    if (window.active === true) {
+        e.value = window.storage.value;
+        e.className = 'app-output__field';
+    }
 }
 function done(e){
-	if (window.active === true) {
-		console.log(window.storage.value);
-		e.value = '\uD83D\uDE4C Alright, your passcode is copied!';
-		e.className = 'app-output__field app-output__field--is-inactive';
-	}
+    if (window.active === true) {
+        //console.log(window.storage.value);
+        e.value = '\uD83D\uDE4C Alright, your passcode is copied!';
+        e.className = 'app-output__field app-output__field--is-inactive';
+    }
 }


### PR DESCRIPTION
Changing the emoji minimum:

With 1,791 emoji, each emoji character provides approximately 10.8-bits of
entropy. If a password cracker can make 1,000,000,000,000 guesses per second
(only need 5 systems of 8 Nvidia GTX 1080 GUPs each running Hashcat 3.0), then
for the attacker to be at least 50% sure he found the correct sequence, we can
expect it to take:

```
55-bits: ~ 5 hours.
60-bits: ~ 7 days,
65-bits: ~ 7 months.
70-bits: ~ 19 years.
75-bits: ~ 600 years.
80-bits: ~ 19 millenia.
```

As such, the default of 4 emoji only provides about 43-bits of entropy. Knowing
the statistics above, means we need to increase our search space. 6 emoji
provide about 65-bits of entropy, and 7 emoji provide about 76-bits of entropy.

Changing the password hashing function:

Passwords should never be hashed with anything other than a dedicated password
hashing function. This means not using generic cryptographic hashing functions
like SHA-256 or SHA-512. Instead, the password should be hashed, on order of
preference, with:

```
* scrypt
* bcrypt
* sha512crypt
* sha256crypt
* PBKDF2
* Argon2 (recent PHC winner- too new)
```

This push changes the default of:

```
base64(sha256(sha512(password)))
```

With:

```
base64(scrypt(password))
```

In this implementation, it uses the recomended settings by Colin Percival of
N=14, r=8, p=1, to provide a 16MB memory cost in addition to the CPU cost. In
my testing on my Intel Core 2 Duo, it takes about 5ms to completion.
